### PR TITLE
__ejabberd_server: Do not auto install from __apt_backports

### DIFF
--- a/type/__ejabberd_server/man.rst
+++ b/type/__ejabberd_server/man.rst
@@ -43,8 +43,31 @@ EXAMPLES
 
 .. code-block:: sh
 
-   # TODO
-   __ejabberd_server
+   # Install ejabberd using the configuration from ~/.skonfig/files/ejabberd.yml
+   __ejabberd_server \
+      --config-source "${__files:?}/ejabberd.yml"
+
+
+   # Install ejabberd from the Debian backports repository
+   __apt_backports
+
+   read -r lsb_codename _ <"${__global:?}/explorer/lsb_codename"
+
+   require=__apt_backports/ \
+   __apt_pin erlang-backports \
+      --package 'erlang*' \
+      --distribution "${lsb_codename:?}-backports" \
+      --priority 600
+
+   require=__apt_backports/ \
+   __apt_pin ejabberd-backports \
+      --package 'ejabberd*' \
+      --distribution "${lsb_codename:?}-backports" \
+      --priority 600
+
+   require='__apt_pin/erlang-backports __apt_pin/ejabberd-backports' \
+   __ejabberd_server \
+      --config-source "${__files:?}/ejabberd.yml"
 
 
 SEE ALSO
@@ -54,12 +77,12 @@ SEE ALSO
 
 AUTHORS
 -------
-Dennis Camera <dennis.camera--@--ssrq-sds-fds.ch>
+Dennis Camera <dennis.camera--@--riiengineering.ch>
 
 
 COPYING
 -------
-Copyright \(C) 2022 Dennis Camera.
+Copyright \(C) 2022-2023 Dennis Camera.
 You can redistribute it and/or modify it under the terms of the GNU General
 Public License as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version.

--- a/type/__ejabberd_server/manifest
+++ b/type/__ejabberd_server/manifest
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2022-2023 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of the skonfig set __ejabberd.
 #
@@ -26,19 +26,12 @@ read -r node_name_should <"${__object:?}/parameter/node-name"
 case ${os:?}
 in
 	(debian|devuan|ubuntu)
-		# enable backports repo
-		# XXX: maybe the type should not be the one to decide whether or not to
-		# use backports
-		__apt_backports
-
 		__debconf_set_selections ejabberd \
 			--line "ejabberd ejabberd/hostname string ${node_name_should#*@}" \
 			--line 'ejabberd ejabberd/user string '
 
-		read -r lsb_codename <"${__global:?}/explorer/lsb_codename"
-
-		require='__apt_backports __debconf_set_selections/ejabberd' \
-		__package_apt ejabberd --target-release "${lsb_codename:?}-backports"
+		require=__debconf_set_selections/ejabberd \
+		__package_apt ejabberd
 
 		ejabberd_require=${ejabberd_require-}${ejabberd_require:+ }__package_apt/ejabberd
 


### PR DESCRIPTION
Some users may want to install the "latest" ejabberd from backports while some may rather stay on the "stable" version.

Instead of automatically configuring the backports repository the procedure to install from backports is now documented in man.rst.